### PR TITLE
ci: run tests against latest Go versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,9 @@ jobs:
     strategy:
       matrix:
         go_version:
-          - "1.11.x"
-          - "1.12.x"
-          - "1.13.x"
-          - "1.14.x"
+          - "1.16.x"
+          - "1.17.x"
+          - "1.18.x"
         os:
           - windows-latest
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,7 @@ jobs:
           - "1.16.x"
           - "1.17.x"
           - "1.18.x"
-        os:
-          - windows-latest
-          - ubuntu-latest
-          - macOS-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v1

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/aereal/go-http-replay
+
+go 1.17


### PR DESCRIPTION
- build: add go.mod
- ci: run tests against latest Go versions
- ci: run tests only on ubuntu-latest for speed up
